### PR TITLE
Add prize selection screen with centered choices

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,13 @@ import './App.css'
 import { Routes, Route } from 'react-router-dom'
 import StartScreen from './screens/StartScreen'
 import GameScreen from './screens/GameScreen'
+import PrizeScreen from './screens/PrizeScreen'
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<StartScreen />} />
+      <Route path="/prize" element={<PrizeScreen />} />
       <Route path="/game" element={<GameScreen />} />
     </Routes>
   )

--- a/src/screens/PrizeScreen.css
+++ b/src/screens/PrizeScreen.css
@@ -1,0 +1,12 @@
+.prize-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  gap: 1rem;
+}
+
+.prize {
+  padding: 1rem 2rem;
+  cursor: pointer;
+}

--- a/src/screens/PrizeScreen.tsx
+++ b/src/screens/PrizeScreen.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from 'react-router-dom'
+import './PrizeScreen.css'
+
+function PrizeScreen() {
+  const navigate = useNavigate()
+
+  const goToGame = () => {
+    navigate('/game')
+  }
+
+  return (
+    <div className="prize-screen">
+      <button className="prize" onClick={goToGame}>Prize 1</button>
+      <button className="prize" onClick={goToGame}>Prize 2</button>
+      <button className="prize" onClick={goToGame}>Prize 3</button>
+    </div>
+  )
+}
+
+export default PrizeScreen

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,5 +1,14 @@
+import { useNavigate } from 'react-router-dom'
+
 function StartScreen() {
-  return <div>Start Screen</div>
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <h1>Start Screen</h1>
+      <button onClick={() => navigate('/prize')}>Start</button>
+    </div>
+  )
 }
 
 export default StartScreen


### PR DESCRIPTION
## Summary
- add PrizeScreen component with three centered buttons for prize selection
- navigate to PrizeScreen from StartScreen and to GameScreen after prize choice
- add route for prize selection

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68923c49f484832a8e1a6560a4813a8e