### PR TITLE
Center images on start and game screens

### DIFF
--- a/src/screens/GameScreen.css
+++ b/src/screens/GameScreen.css
@@ -1,0 +1,6 @@
+.game-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -1,5 +1,12 @@
+import './GameScreen.css'
+import map from '../assets/map.svg'
+
 function GameScreen() {
-  return <div>Game Screen</div>
+  return (
+    <div className="game-screen">
+      <img src={map} alt="Map" />
+    </div>
+  )
 }
 
 export default GameScreen

--- a/src/screens/StartScreen.css
+++ b/src/screens/StartScreen.css
@@ -1,0 +1,6 @@
+.start-screen {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,5 +1,12 @@
+import './StartScreen.css'
+import logo from '../assets/logo.svg'
+
 function StartScreen() {
-  return <div>Start Screen</div>
+  return (
+    <div className="start-screen">
+      <img src={logo} alt="Logo" />
+    </div>
+  )
 }
 
 export default StartScreen


### PR DESCRIPTION
## Summary
- center logo on start screen using CSS
- center map on game screen using CSS

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689319a37ae8832a82c36ce354483dba