### PR TITLE
Enable navigation from start screen to game screen

### DIFF
--- a/src/screens/StartScreen.tsx
+++ b/src/screens/StartScreen.tsx
@@ -1,11 +1,18 @@
 import './StartScreen.css'
 import logo from '../assets/logo.svg'
+import { useNavigate } from 'react-router-dom'
 
 function StartScreen() {
+    const navigate = useNavigate()
+
     return (
         <div className="start-screen">
             <img src={logo} alt="Logo"/>
-            <div role="button" className={'start-button'}>
+            <div
+                role="button"
+                className={'start-button'}
+                onClick={() => navigate('/game')}
+            >
                 Start
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add react-router navigation to StartScreen button so clicking Start shows the game screen

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68934555d7ac832a968489aa82a493b8