### PR TITLE
Add hidden centered popup to game screen

### DIFF
--- a/src/screens/GameScreen.css
+++ b/src/screens/GameScreen.css
@@ -3,4 +3,18 @@
   justify-content: center;
   align-items: center;
   height: 100vh;
+  position: relative;
+}
+
+.popup {
+  display: none;
+  position: absolute;
+  width: 876px;
+  height: 588px;
+  background: white;
+  border: 4px solid black;
+  border-radius: 57px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -5,6 +5,7 @@ function GameScreen() {
   return (
     <div className="game-screen">
       <img src={map} alt="Map" />
+      <div className="popup" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add hidden popup element to game screen
- style popup centered with specified size and border

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6893469284d8832a8976dddfaa6eac6c