### PR TITLE
Add definitions for all item images

### DIFF
--- a/src/components/definitions.ts
+++ b/src/components/definitions.ts
@@ -1,23 +1,337 @@
 import Bear from "../assets/items/bear.svg"
+import BigBen from "../assets/items/big-ben.svg"
+import Boomerang from "../assets/items/boomerang.svg"
+import Buddah from "../assets/items/buddah.svg"
+import Camel from "../assets/items/camel.svg"
+import Car from "../assets/items/car.svg"
+import Cathedral from "../assets/items/cathedral.svg"
+import Clownfish from "../assets/items/clownfish.svg"
+import Dancer from "../assets/items/dancer.svg"
+import Djembe from "../assets/items/djembe.svg"
+import Dragon from "../assets/items/dragon.svg"
+import Eagle from "../assets/items/eagle.svg"
+import Elephant from "../assets/items/elephant.svg"
+import Frida from "../assets/items/frida.svg"
+import Frog from "../assets/items/frog.svg"
+import Giraffe from "../assets/items/giraffe.svg"
+import Guitar from "../assets/items/guitar.svg"
+import Hamburger from "../assets/items/hamburger.svg"
+import Hockey from "../assets/items/hockey.svg"
+import Iceberg from "../assets/items/iceberg.svg"
+import Jesus from "../assets/items/jesus.svg"
+import Jug from "../assets/items/jug.svg"
+import Kangaroo from "../assets/items/kangaroo.svg"
+import Maasai from "../assets/items/maasai.svg"
+import Panda from "../assets/items/panda.svg"
+import Penguin from "../assets/items/penguin.svg"
+import PolarBear from "../assets/items/polar-bear.svg"
+import Reindeer from "../assets/items/reindeer.svg"
+import Spahetti from "../assets/items/spahetti.svg"
+import Statue from "../assets/items/statue.svg"
+import Temple from "../assets/items/temple.svg"
+import Totem from "../assets/items/totem.svg"
+import Toucan from "../assets/items/toucan.svg"
+import Turtle from "../assets/items/turtle.svg"
+import Viking from "../assets/items/viking.svg"
+import Whale from "../assets/items/whale.svg"
 
 export interface ItemDefinition {
-    image: string
-    x: number
-    y: number
-    descriptionImage: string
-    descriptionText: string
-    descriptionTitle: string
+  image: string
+  x: number
+  y: number
+  descriptionImage: string
+  descriptionText: string
+  descriptionTitle: string
 }
 
-
-
 export const itemDefinitions: ItemDefinition[] = [
-    {
-        image: Bear,
-        x: 0,
-        y: 0,
-        descriptionImage: "",
-        descriptionText: "",
-        descriptionTitle: ""
-    }
+  {
+    image: Bear,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: BigBen,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Boomerang,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Buddah,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Camel,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Car,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Cathedral,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Clownfish,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Dancer,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Djembe,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Dragon,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Eagle,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Elephant,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Frida,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Frog,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Giraffe,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Guitar,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Hamburger,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Hockey,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Iceberg,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Jesus,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Jug,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Kangaroo,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Maasai,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Panda,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Penguin,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: PolarBear,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Reindeer,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Spahetti,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Statue,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Temple,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Totem,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Toucan,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Turtle,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Viking,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
+  {
+    image: Whale,
+    x: 0,
+    y: 0,
+    descriptionImage: "",
+    descriptionText: "",
+    descriptionTitle: "",
+  },
 ]
+


### PR DESCRIPTION
## Summary
- add imports for all item asset SVGs
- populate itemDefinitions with placeholder entries for each image

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68934e5f12cc832aa795047e69e120a0