### PR TITLE
feat: add coin collection logic

### DIFF
--- a/src/components/Coin.tsx
+++ b/src/components/Coin.tsx
@@ -7,10 +7,15 @@ export interface CoinDefinition {
     y: number
 }
 
+interface CoinProps extends CoinDefinition {
+    onClick?: () => void
+}
+
 function Coin({
                   x,
                   y,
-              }: CoinDefinition) {
+                  onClick,
+              }: CoinProps) {
     const style: CSSProperties = {
         position: 'absolute',
         left: x,
@@ -19,7 +24,7 @@ function Coin({
 
 
     return (
-        <div role={"button"} style={style}>
+        <div role={"button"} style={style} onClick={onClick}>
             <img src={CoinImage} alt={"coin"}/>
         </div>
     )

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -1,14 +1,26 @@
 import './GameScreen.css'
 import map from '../assets/map.png'
-import MapItem from "../components/MapItem.tsx";
+import MapItem from "../components/MapItem.tsx"
 import BackArrow from "../assets/back-arrow.svg"
 import SmallCoin from "../assets/small-coin.svg"
+import {useState} from 'react'
 
-import {coins} from "../components/coins.ts";
-import Coin from "../components/Coin.tsx";
-import {itemDefinitions} from "../components/definitions.ts";
+import {coins} from "../components/coins.ts"
+import Coin from "../components/Coin.tsx"
+import {itemDefinitions} from "../components/definitions.ts"
 
 function GameScreen() {
+    const [collectedCoins, setCollectedCoins] = useState(0)
+    const [visibleCoins, setVisibleCoins] = useState(coins)
+    const [popupVisible, setPopupVisible] = useState(false)
+    const maxCoins = coins.length
+
+    const handleCoinClick = (index: number) => {
+        setVisibleCoins((prev) => prev.filter((_, i) => i !== index))
+        setCollectedCoins((prev) => prev + 1)
+        setPopupVisible(true)
+    }
+
     return (
         <div className="game-screen">
             <div className="game-map">
@@ -17,24 +29,24 @@ function GameScreen() {
                     <span>powrót</span>
                 </div>
                 <div role="button" className="interface-button coin-button">
-                    <span className={"bigger"}>8</span>/15
+                    <span className={"bigger"}>{collectedCoins}</span>/{maxCoins}
                     <SmallCoin/>
                 </div>
                 <img style={{opacity: 1}} src={map} alt="Map"/>
-                {coins.map((coin) => (
-                    <Coin x={coin.x} y={coin.y} />
+                {visibleCoins.map((coin, index) => (
+                    <Coin key={index} x={coin.x} y={coin.y} onClick={() => handleCoinClick(index)} />
                 ))}
 
                 {itemDefinitions.map((item) => (
                     <MapItem image={item.image} x={item.x - 10} y={item.y + 30} descriptionImage={item.descriptionImage} descriptionText={item.descriptionText} descriptionTitle={item.descriptionTitle} />
                 ))}
             </div>
-            <div className="popup">
+            <div className="popup" style={{display: popupVisible ? 'block' : 'none'}}>
                 <div className="header">
                     Bonus!
                 </div>
                 <div className={"footer"}>
-                    <div role={"button"} className={"popup-button"}>
+                    <div role={"button"} className={"popup-button"} onClick={() => setPopupVisible(false)}>
                         Graj dalej
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- track collected coins and remaining coins on the game screen
- hide coins, increment counter and show popup when a coin is collected

## Testing
- `yarn lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68936166ecd8832aa8f07b34b76763e1