### PR TITLE
Handle map item click to show popup

### DIFF
--- a/src/components/MapItem.tsx
+++ b/src/components/MapItem.tsx
@@ -1,14 +1,11 @@
-import type { CSSProperties } from 'react'
-import type {ItemDefinition} from "./definitions.ts";
+import type {CSSProperties} from 'react'
+import type {ItemDefinition} from './definitions.ts'
 
-function MapItem({
-  image,
-  x,
-  y,
-  descriptionImage,
-  descriptionText,
-  descriptionTitle,
-}: ItemDefinition) {
+interface MapItemProps extends ItemDefinition {
+  onClick?: () => void
+}
+
+function MapItem({image, x, y, onClick}: MapItemProps) {
   const style: CSSProperties = {
     position: 'absolute',
     left: x,
@@ -17,11 +14,9 @@ function MapItem({
 
   const ImageComponent = image
 
-  console.log(ImageComponent, descriptionImage, descriptionText, descriptionTitle)
-
   return (
-    <div role={"button"} style={style}>
-      <ImageComponent />
+    <div role={"button"} style={style} onClick={onClick}>
+      <ImageComponent/>
     </div>
   )
 }

--- a/src/components/definitions.ts
+++ b/src/components/definitions.ts
@@ -34,9 +34,10 @@ import Toucan from "../assets/items/toucan.svg"
 import Turtle from "../assets/items/turtle.svg"
 import Viking from "../assets/items/viking.svg"
 import Whale from "../assets/items/whale.svg"
+import type {ComponentType, SVGProps} from 'react'
 
 export interface ItemDefinition {
-  image: string
+  image: ComponentType<SVGProps<SVGSVGElement>>
   x: number
   y: number
   descriptionImage: string

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -14,12 +14,18 @@ function GameScreen() {
     const navigate = useNavigate()
     const [collectedCoins, setCollectedCoins] = useState(0)
     const [visibleCoins, setVisibleCoins] = useState(coins)
+    const [visibleItems, setVisibleItems] = useState(itemDefinitions)
     const [popupVisible, setPopupVisible] = useState(false)
     const maxCoins = coins.length
 
     const handleCoinClick = (index: number) => {
         setVisibleCoins((prev) => prev.filter((_, i) => i !== index))
         setCollectedCoins((prev) => prev + 1)
+        setPopupVisible(true)
+    }
+
+    const handleItemClick = (index: number) => {
+        setVisibleItems((prev) => prev.filter((_, i) => i !== index))
         setPopupVisible(true)
     }
 
@@ -41,9 +47,12 @@ function GameScreen() {
                     <Coin key={index} x={coin.x} y={coin.y} onClick={() => handleCoinClick(index)}/>
                 ))}
 
-                {itemDefinitions.map((item) => (
-                    <MapItem image={item.image} x={item.x} y={item.y} descriptionImage={item.descriptionImage}
-                             descriptionText={item.descriptionText} descriptionTitle={item.descriptionTitle}/>
+                {visibleItems.map((item, index) => (
+                    <MapItem key={index} image={item.image} x={item.x} y={item.y}
+                             descriptionImage={item.descriptionImage}
+                             descriptionText={item.descriptionText}
+                             descriptionTitle={item.descriptionTitle}
+                             onClick={() => handleItemClick(index)}/>
                 ))}
             </div>
             <div className="popup" style={{display: popupVisible ? 'block' : 'none'}}>


### PR DESCRIPTION
## Summary
- Show popup and hide item when a map item is clicked
- Add optional click handler to MapItem and tighten item image typing
- Track visible map items on the game screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68936e4f7b10832ab93d65a8d5bb34ff