### PR TITLE
Fix build errors

### DIFF
--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  import type { ComponentType, SVGProps } from 'react';
+  const component: ComponentType<SVGProps<SVGSVGElement>>;
+  export default component;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />


### PR DESCRIPTION
## Summary
- include SVGR client types in Vite env declaration so TypeScript understands React SVG imports
- declare SVG modules to resolve to React components

## Testing
- `yarn build`
- `yarn lint && echo lint:ok`


------
https://chatgpt.com/codex/tasks/task_e_6893727d1834832ab37daf55783af599