### PR TITLE
feat: add coin definitions and popup text

### DIFF
--- a/src/components/Coin.tsx
+++ b/src/components/Coin.tsx
@@ -1,12 +1,7 @@
 import type {CSSProperties} from 'react'
 
 import CoinImage from "../assets/coin.webp"
-
-export interface CoinDefinition {
-    id: string
-    x: number
-    y: number
-}
+import type {CoinDefinition} from "./coins.ts"
 
 interface CoinProps extends CoinDefinition {
     onClick?: () => void

--- a/src/components/coins.ts
+++ b/src/components/coins.ts
@@ -1,26 +1,118 @@
-interface Coin {
+export interface CoinDefinition {
     id: string
     x: number
     y: number
+    descriptionText: string
 }
 
-export const coins: Coin[] = [
-    {id: "1", x: 432, y: 220},
-    {id: "2", x: 330, y: 380},
-    {id: "3", x: 470, y: 414},
-    {id: "4", x: 390, y: 563},
-    {id: "5", x: 596, y: 680},
-    {id: "6", x: 502, y: 885},
-    {id: "7", x: 718, y: 309},
-    {id: "8", x: 788, y: 523},
-    {id: "9", x: 941, y: 667},
-    {id: "10", x: 874, y: 382},
-    {id: "11", x: 1018, y: 230},
-    {id: "12", x: 1103, y: 372},
-    {id: "13", x: 1273, y: 185},
-    {id: "14", x: 1350, y: 328},
-    {id: "15", x: 1064, y: 532},
-    {id: "16", x: 941, y: 667},
-    {id: "17", x: 1382, y: 723},
-    {id: "18", x: 1243, y: 812},
+export const coins: CoinDefinition[] = [
+    {
+        id: "1",
+        x: 432,
+        y: 220,
+        descriptionText: `Czy wiesz, że porcelanowe muszle kauri były najdłużej obowiązującą globalną walutą (tak zwanym płacidłem) od czasów starożytnych do niemal współczesnych, od Azji, przez Bliski i Daleki Wschód, Afrykę po Amerykę Północną? Płacono nimi zanim pojawiły się pieniądze z kruszcu (srebra, złota, innych metali). Były trwałe, cenne, policzalne, trudno dostępne (trzymały wartość) i symbolizowały bogactwo. Pierwotnie najbardziej rozpowszechnione były w okolicach Malediwów (Azja), gdzie żyło najwięcej tych mięczaków.`,
+    },
+    {
+        id: "2",
+        x: 330,
+        y: 380,
+        descriptionText: `Pierwsze monety powstały w VII w. p.n.e. w Lidii (dzisiejsza zachodnia Turcja), gdzie wybito pierwsze na świecie standaryzowane monety ze stopu złota i srebra (elektronu). Miały ściśle określoną masę, wielkość i skład. Gwarantowany przez władcę stempel potwierdzał ich wagę i jakość. Monety były odporne na wahania wartości, były trwałe i miały niewielkie rozmiary, co ułatwiało handel.`,
+    },
+    {
+        id: "3",
+        x: 470,
+        y: 414,
+        descriptionText: `Pierwsze banknoty pojawiły się w Chinach. Już za dynastii Tang (VII w. n.e.) kupcy i urzędnicy zaczęli używać kwitów depozytowych (określanych jako latające pieniądze), aby uniknąć transportu ciężkich monet. W XI wieku, za dynastii Song, rząd chiński w Syczuanie oficjalnie przejął ten pomysł, emitując pierwsze państwowe banknoty na świecie, zwane "jiaozi". Każdy banknot miał rozmiar mniej więcej kartki formatu A4. Wydrukowane banknoty przedstawiające sceny pasterskie, miały czerwony stempel potwierdzający ich autentyczność.`,
+    },
+    {
+        id: "4",
+        x: 390,
+        y: 563,
+        descriptionText: `Starożytni Grecy jako pierwsi umieszczali na monetach wizerunki bóstw i władców, czyniąc z nich narzędzie propagandy. Podstawową monetą używaną w starożytnej Grecji była drachma, dzielona na 6 oboli lub 48 chalków. Rzymianie z kolei stworzyli jednolity system monetarny oparty na denarze, który ułatwiał handel w całym imperium i przetrwał setki lat.`,
+    },
+    {
+        id: "5",
+        x: 596,
+        y: 680,
+        descriptionText: `Pierwszą monetą, jaką wybito w Polsce w X wieku, był denar z wizerunkiem pierwszego władcy, Mieszka I.`,
+    },
+    {
+        id: "6",
+        x: 502,
+        y: 885,
+        descriptionText: `Pomysł papierowych pieniędzy przywędrował do Europy wraz z podróżami Marco Polo, ale początkowo traktowano je jako ciekawostkę. Pierwsze oficjalne banknoty w Europie wyemitował Stockholms Banco w Szwecji w 1661 roku. Były odpowiedzią na problem transportu dużych, ciężkich monet płytowych.`,
+    },
+    {
+        id: "7",
+        x: 718,
+        y: 309,
+        descriptionText: `Banknot 1000 franków szwajcarskich jest najcenniejszym banknotem na świecie, który jest używany na co dzień. Warty jest około 1150 dolarów amerykańskich i bardzo trudno go podrobić.`,
+    },
+    {
+        id: "8",
+        x: 788,
+        y: 523,
+        descriptionText: `Wampum – pasy i sznury koralików wykonanych z fioletowych i białych muszli – pełniły rolę waluty u rdzennych mieszkańców Ameryki, służąc także do zawierania traktatów, przekazywania informacji i celów ceremonialnych.`,
+    },
+    {
+        id: "9",
+        x: 941,
+        y: 667,
+        descriptionText: `Dolar amerykański wywodzi się bezpośrednio od dolara hiszpańskiego. Hiszpania produkowała swoje monety w koloniach Ameryki z powodu braku kruszcu w Europie, co uczyniło dolar hiszpański popularnym i doprowadziło do przyjęcia dolara jako waluty Stanów Zjednoczonych w 1785 roku.`,
+    },
+    {
+        id: "10",
+        x: 874,
+        y: 382,
+        descriptionText: `Nazwa najpopularniejszej waluty świata, dolara, pochodzi od srebrnej monety bitej w XVI wieku w Jáchymovie przez czeskiego hrabiego Schlicka. Monetę tę nazywano "Joachimsthaler", co skrócono do "talar", a z czasem przekształciło się w "dolar".`,
+    },
+    {
+        id: "11",
+        x: 1018,
+        y: 230,
+        descriptionText: `W 2011 roku w Australii wybito największą, najcięższą i najdroższą monetę na świecie. Zrobiona z czystego złota, ważyła tonę, miała 80 cm średnicy i 12 cm grubości. Jej wartość nominalna wynosiła milion dolarów australijskich, a rynkowa aż 53,5 miliona.`,
+    },
+    {
+        id: "12",
+        x: 1103,
+        y: 372,
+        descriptionText: `Australia jako pierwsza na świecie w 1988 roku wprowadziła do obiegu banknoty polimerowe – trwalsze od papierowych i trudniejsze do sfałszowania. Od 1996 roku wszystkie australijskie banknoty są wykonane z tego materiału.`,
+    },
+    {
+        id: "13",
+        x: 1273,
+        y: 185,
+        descriptionText: `Manile – otwarte bransolety z brązu, miedzi lub mosiądzu – stały się ważnym środkiem płatniczym w handlu z Europejczykami w Afryce od XV wieku, niestety odgrywając główną rolę w handlu niewolnikami.`,
+    },
+    {
+        id: "14",
+        x: 1350,
+        y: 328,
+        descriptionText: `W wielu społecznościach rolniczych, na przykład wśród Masajów, to bydło było głównym miernikiem bogactwa i środkiem płatniczym przy ważnych transakcjach, jak zawarcie małżeństwa. Egipcjanie do dziś proponują zapłatę za żonę w wielbłądach. Dawno temu w Afryce jako pieniądz służyły również sól, muszelki, koraliki, metale, biżuteria, tkaniny, broń i narzędzia – liczyło się to, co było akceptowane i wartościowe dla ludzi.`,
+    },
+    {
+        id: "15",
+        x: 1064,
+        y: 532,
+        descriptionText: `Tugrik, znany również jako tögrög, jest oficjalną walutą Mongolii, a jego nazwa pochodzi od mongolskiego słowa oznaczającego „okrągły”, odnoszącego się do kształtu monet.`,
+    },
+    {
+        id: "16",
+        x: 941,
+        y: 667,
+        descriptionText: `Najbardziej wartościowym banknotem na świecie był banknot 10 000 dolarów singapurskich, wart około 30 000 złotych. Używano go w obiegu do 2014 roku i nadal można nim legalnie płacić.`,
+    },
+    {
+        id: "17",
+        x: 1382,
+        y: 723,
+        descriptionText: `Pierwszy na świecie bankomat został zainstalowany w Londynie w 1967 roku przez Barclays Bank. Zamiast kart używano specjalnych voucherów z jednorazowym kodem, a konstruktor wzorował się na maszynie wydającej gumy do żucia.`,
+    },
+    {
+        id: "18",
+        x: 1243,
+        y: 812,
+        descriptionText: `Na Antarktydzie istnieje dolar antarktyczny, lecz nie jest to oficjalny środek płatniczy. Na kontynencie płaci się dolarami amerykańskimi, euro oraz walutami obowiązującymi na statkach kursujących do Antarktydy.`,
+    },
 ]
+

--- a/src/screens/GameScreen.css
+++ b/src/screens/GameScreen.css
@@ -46,6 +46,11 @@
   color: #FFFFFF;
 }
 
+.popup .content {
+  padding: 120px 40px 100px;
+  font-size: 32px;
+}
+
 .popup-button {
   width: 214px;
   height: 58px;

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -16,16 +16,21 @@ function GameScreen() {
     const [visibleCoins, setVisibleCoins] = useState(coins)
     const [visibleItems, setVisibleItems] = useState(itemDefinitions)
     const [popupVisible, setPopupVisible] = useState(false)
+    const [popupText, setPopupText] = useState("")
     const maxCoins = coins.length
 
     const handleCoinClick = (index: number) => {
+        const coin = visibleCoins[index]
         setVisibleCoins((prev) => prev.filter((_, i) => i !== index))
         setCollectedCoins((prev) => prev + 1)
+        setPopupText(coin.descriptionText)
         setPopupVisible(true)
     }
 
     const handleItemClick = (index: number) => {
+        const item = visibleItems[index]
         setVisibleItems((prev) => prev.filter((_, i) => i !== index))
+        setPopupText(item.descriptionText)
         setPopupVisible(true)
     }
 
@@ -44,7 +49,7 @@ function GameScreen() {
                 </div>
                 <img src={mapImage} alt="Map" />
                 {visibleCoins.map((coin, index) => (
-                    <Coin key={index} id={coin.id} x={coin.x} y={coin.y} onClick={() => handleCoinClick(index)}/>
+                    <Coin key={index} {...coin} onClick={() => handleCoinClick(index)}/>
                 ))}
 
                 {visibleItems.map((item, index) => (
@@ -59,6 +64,7 @@ function GameScreen() {
                 <div className="header">
                     Bonus!
                 </div>
+                <div className="content">{popupText}</div>
                 <div className={"footer"}>
                     <div role={"button"} className={"popup-button"} onClick={() => setPopupVisible(false)}>
                         Graj dalej


### PR DESCRIPTION
## Summary
- add informative text for each coin
- show coin text in popup after collecting a coin
- style popup content area

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3f2355c64832a9a4fee1a4a9e228c