### PR TITLE
Add sandbox mode with simulation controls

### DIFF
--- a/sandbox.html
+++ b/sandbox.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Skarbiec z całego świata - Sandbox</title>
+    <style>
+      body { margin: 0; display: flex; min-height: 100vh; }
+      #root { flex: 1; }
+      #sandbox-controls { width: 250px; border-left: 1px solid #ccc; padding: 1rem; background: #f7f7f7; box-sizing: border-box; }
+      #sandbox-controls h2 { margin-top: 0; }
+      #sandbox-controls button { display: block; width: 100%; margin-bottom: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <div id="sandbox-controls"></div>
+    <script type="module" src="/src/sandbox.tsx"></script>
+  </body>
+</html>

--- a/src/components/SandboxControls.tsx
+++ b/src/components/SandboxControls.tsx
@@ -1,0 +1,29 @@
+import {useState} from 'react'
+
+interface Member {
+  id: number
+  name: string
+}
+
+export default function SandboxControls() {
+  const [nextId, setNextId] = useState(1)
+
+  const addMember = () => {
+    const member: Member = { id: nextId, name: `Member ${nextId}` }
+    window.dispatchEvent(new CustomEvent('sandbox:add-member', { detail: member }))
+    setNextId((id) => id + 1)
+  }
+
+  const setLeader = () => {
+    const id = Math.max(1, nextId - 1)
+    window.dispatchEvent(new CustomEvent('sandbox:set-leader', { detail: { id } }))
+  }
+
+  return (
+    <div className="sandbox-controls">
+      <h2>Sandbox</h2>
+      <button onClick={addMember}>Add team member</button>
+      <button onClick={setLeader}>Set leader</button>
+    </div>
+  )
+}

--- a/src/sandbox.tsx
+++ b/src/sandbox.tsx
@@ -1,0 +1,20 @@
+import {StrictMode} from 'react'
+import {createRoot} from 'react-dom/client'
+import {MemoryRouter} from 'react-router-dom'
+import './index.css'
+import App from './App.tsx'
+import SandboxControls from './components/SandboxControls.tsx'
+
+const rootElement = document.getElementById('root')!
+createRoot(rootElement).render(
+  <StrictMode>
+    <MemoryRouter>
+      <App />
+    </MemoryRouter>
+  </StrictMode>,
+)
+
+const controlsElement = document.getElementById('sandbox-controls')
+if (controlsElement) {
+  createRoot(controlsElement).render(<SandboxControls />)
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import {defineConfig} from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import svgr from "vite-plugin-svgr";
+import {resolve} from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -9,4 +10,12 @@ export default defineConfig({
             svgrOptions: {exportType: "default", ref: true, svgo: false, titleProp: true},
             include: "**/*.svg",
         }),],
+    build: {
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, 'index.html'),
+                sandbox: resolve(__dirname, 'sandbox.html'),
+            },
+        },
+    },
 })


### PR DESCRIPTION
## Summary
- add standalone sandbox.html with side controls for simulating team events
- wire sandbox.tsx entry point and SandboxControls component dispatching custom events
- include sandbox build input in vite config

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_68b4012c6cd8832a82b83ba268e71e16