### PR TITLE
Add mission instructions button to GameScreen

### DIFF
--- a/src/screens/GameScreen.css
+++ b/src/screens/GameScreen.css
@@ -144,3 +144,9 @@
   right: 15px;
 }
 
+.task-button {
+  left: 50%;
+  transform: translateX(-50%);
+  width: 200px;
+}
+

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -17,6 +17,7 @@ function GameScreen() {
     const [visibleItems, setVisibleItems] = useState(itemDefinitions)
     const [popupVisible, setPopupVisible] = useState(false)
     const [popupText, setPopupText] = useState("")
+    const [popupTitle, setPopupTitle] = useState("Odkrycie!")
     const maxCoins = coins.length
     const gameScreenRef = useRef<HTMLDivElement>(null);
 
@@ -38,8 +39,10 @@ function GameScreen() {
         const newCount = collectedCoins + 1
         setCollectedCoins(newCount)
         if (newCount === maxCoins) {
+            setPopupTitle("Odkrycie!")
             setPopupText("Brawo! Jesteś prawdziwym odkrywcą! Udało Ci się zebrać wszystkie skarby z mapy i poznać ich historie.")
         } else {
+            setPopupTitle("Odkrycie!")
             setPopupText(coin.descriptionText)
         }
         setPopupVisible(true)
@@ -48,7 +51,14 @@ function GameScreen() {
     const handleItemClick = (index: number) => {
         const item = visibleItems[index]
         setVisibleItems((prev) => prev.filter((_, i) => i !== index))
+        setPopupTitle("Odkrycie!")
         setPopupText(item.descriptionText)
+        setPopupVisible(true)
+    }
+
+    const handleTaskClick = () => {
+        setPopupTitle("Twoje zadanie")
+        setPopupText("Odkryj skarby całego świata! Twoja misja: na tej mapie ukryły się małe, błyszczące monety. Spróbuj je wszystkie odnaleźć i kliknąć! Za każdy skarb dostaniesz punkt, a potem dowiesz się czegoś ciekawego o pieniądzach z danego miejsca!")
         setPopupVisible(true)
     }
 
@@ -65,6 +75,9 @@ function GameScreen() {
                     </span>
                     <SmallCoin/>
                 </div>
+                <div role="button" className="interface-button task-button" onClick={handleTaskClick}>
+                    Twoje zadanie
+                </div>
                 <img src={mapImage} alt="Map" />
                 {visibleCoins.map((coin) => (
                     <Coin key={coin.id} {...coin} onClick={() => handleCoinClick(coin)}/>
@@ -80,7 +93,7 @@ function GameScreen() {
             </div>
             <div className="popup" style={{display: popupVisible ? 'block' : 'none'}}>
                 <div className="header">
-                    Odkrycie!
+                    {popupTitle}
                 </div>
                 <div className="content">{popupText}</div>
                 <div className={"footer"}>


### PR DESCRIPTION
## Summary
- add top-center "Twoje zadanie" button that opens mission popup
- allow popup to show dynamic titles and style the new task button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be05354aa4832ab54c13b424992f46